### PR TITLE
Refine for linux

### DIFF
--- a/src/utils/concurrent.cpp
+++ b/src/utils/concurrent.cpp
@@ -32,100 +32,31 @@ static void* mmThreadRun(void* p) {
 }
 
 namespace phxpaxos {
-
-///////////////////////////////////////////////////////////ThreadAttr
-
-ThreadAttr::ThreadAttr() {
-    if (pthread_attr_init(&_attr) != 0) {
-        throw ThreadException("pthread_attr_init error");
-    }
-}
-
-ThreadAttr::~ThreadAttr() {
-    pthread_attr_destroy(&_attr);
-}
-
-void ThreadAttr::setScope(bool sys) {
-    int scope = sys ? PTHREAD_SCOPE_SYSTEM : PTHREAD_SCOPE_PROCESS;
-    pthread_attr_setscope(&_attr, scope);
-}
-
-void ThreadAttr::setStackSize(size_t n) {
-    pthread_attr_setstacksize(&_attr, n);
-}
-
-void ThreadAttr::setDetached(bool detached) {
-    int state = detached ? PTHREAD_CREATE_DETACHED : PTHREAD_CREATE_JOINABLE;
-    pthread_attr_setdetachstate(&_attr, state);
-}
-
-void ThreadAttr::setPriority(int prio) {
-    sched_param param;
-
-    pthread_attr_getschedparam(&_attr, &param);
-    param.sched_priority = prio;
-
-    pthread_attr_setschedparam(&_attr, &param);
-}
-
-pthread_attr_t* ThreadAttr::impl() {
-    return &_attr;
-}
-
 ///////////////////////////////////////////////////////////Thread
 
-Thread::Thread() : _thread(0) {}
+Thread::Thread() {}
 
 Thread::~Thread() {}
 
 void Thread::start() {
-    int rc = pthread_create(&_thread, 0, mmThreadRun, this);
-    if (rc != 0) {
-        throw ThreadException("pthread_create error");
-    }
+    _thread = std::thread(std::bind(&mmThreadRun, this));
 }
 
-void Thread::start(ThreadAttr& attr) {
-    int rc = pthread_create(&_thread, attr.impl(), mmThreadRun, this);
-    if (rc != 0) {
-        throw ThreadException("pthread_create error");
-    }
-}
 
 void Thread::join() {
-    int rc = pthread_join(_thread, 0);
-    if (rc != 0) {
-        throw ThreadException("pthread_join error");
-    }
+    _thread.join();
 }
 
 void Thread::detach() {
-    int rc = pthread_detach(_thread);
-    if (rc != 0) {
-        throw ThreadException("pthread_detach error");
-    }
+    _thread.detach();
 }
     
-pthread_t Thread::getId() const {
-    return _thread;
-}
-
-void Thread::kill(int sig) {
-    int rc = pthread_kill(_thread, sig);
-    if (rc != 0) {
-        throw ThreadException("pthread_kill error");
-    }
+std::thread::id Thread::getId() const {
+    return _thread.get_id();
 }
 
 void Thread::sleep(int ms) {
-    timespec t;
-    t.tv_sec = ms / 1000;
-    t.tv_nsec = (ms % 1000) * 1000000;
-
-    int ret = 0;
-    do {
-        ret = ::nanosleep(&t, &t);
-    } while (ret == -1 && errno == EINTR);
+    std::this_thread::sleep_for(std::chrono::milliseconds(ms));
 }
 
 } 

--- a/src/utils/concurrent.h
+++ b/src/utils/concurrent.h
@@ -37,31 +37,12 @@ See the AUTHORS file for names of contributors.
 #include <string>
 #include <condition_variable>
 #include <mutex>
+#include <thread>
 
 namespace phxpaxos {
 
 using std::deque;
 
-class ThreadAttr {
-public:
-    ThreadAttr();
-
-    ~ThreadAttr();
-
-    void setScope(bool sys);
-
-    void setStackSize(size_t n);
-
-    void setDetached(bool detached);
-
-    void setPriority(int prio);
-    
-    pthread_attr_t* impl();
-
-private:
-
-    pthread_attr_t _attr;
-};
 
 class Thread : public Noncopyable {
 public:
@@ -71,22 +52,18 @@ public:
 
     void start();
 
-    void start(ThreadAttr& attr);
-
     void join();
 
     void detach();
     
-    pthread_t getId() const;
-
-    void kill(int sig);
+    std::thread::id getId() const;
 
     virtual void run() = 0;
 
     static void sleep(int ms);
 
 protected:
-    pthread_t _thread;
+    std::thread _thread;
 };
 
 template <class T>

--- a/src/utils/concurrent.h
+++ b/src/utils/concurrent.h
@@ -92,7 +92,7 @@ protected:
 template <class T>
 class Queue {
 public:
-    Queue() : _lock(_mutex), _size(0) { _lock.unlock(); }
+    Queue() : _size(0) {}
 
     virtual ~Queue() {}
 
@@ -177,11 +177,11 @@ public:
     }
 
     virtual void lock() {
-        _mutex.lock();
+        _lock.lock();
     }
 
     virtual void unlock() {
-        _mutex.unlock();
+        _lock.unlock();
     }
 
     void swap(Queue& q) {
@@ -192,9 +192,8 @@ public:
     }
 
 protected:
-    std::mutex _mutex;
-    std::unique_lock<std::mutex> _lock;
-    std::condition_variable _cond;
+    std::mutex _lock;
+    std::condition_variable_any _cond;
     deque<T> _storage;
     size_t _size;
 };

--- a/src/utils/serial_lock.cpp
+++ b/src/utils/serial_lock.cpp
@@ -25,9 +25,8 @@ See the AUTHORS file for names of contributors.
 namespace phxpaxos
 {
 
-SerialLock :: SerialLock() : m_oLock(m_oMutex)
+SerialLock :: SerialLock()
 {
-    m_oLock.unlock();
 }
 
 SerialLock :: ~SerialLock()
@@ -46,7 +45,7 @@ void SerialLock :: UnLock()
 
 void SerialLock :: Wait()
 {
-    m_oCond.wait(m_oLock);
+    m_oCond.wait(m_oMutex);
 }
 
 void SerialLock :: Interupt()
@@ -56,7 +55,7 @@ void SerialLock :: Interupt()
 
 bool SerialLock :: WaitTime(const int iTimeMs)
 {
-    return m_oCond.wait_for(m_oLock, std::chrono::milliseconds(iTimeMs)) != std::cv_status::timeout;
+    return m_oCond.wait_for(m_oMutex, std::chrono::milliseconds(iTimeMs)) != std::cv_status::timeout;
 }
 
 }

--- a/src/utils/serial_lock.h
+++ b/src/utils/serial_lock.h
@@ -43,8 +43,7 @@ public:
 
 private:
     std::mutex m_oMutex;
-    std::unique_lock<std::mutex> m_oLock;
-    std::condition_variable m_oCond;
+    std::condition_variable_any m_oCond;
 };
 
 }

--- a/src/utils/util.cpp
+++ b/src/utils/util.cpp
@@ -27,6 +27,7 @@ See the AUTHORS file for names of contributors.
 #include <time.h>
 #include <errno.h>
 #include <math.h>
+#include <thread>
 
 namespace phxpaxos {
 
@@ -48,15 +49,7 @@ const uint64_t Time :: GetSteadyClockMS()
 
 void Time :: MsSleep(const int iTimeMs)
 {
-    timespec t;
-    t.tv_sec = iTimeMs / 1000; 
-    t.tv_nsec = (iTimeMs % 1000) * 1000000;
-
-    int ret = 0;
-    do 
-    {
-        ret = ::nanosleep(&t, &t);
-    } while (ret == -1 && errno == EINTR); 
+    std::this_thread::sleep_for(std::chrono::milliseconds(iTimeMs));
 }
 
 /////////////////////////////////////////////


### PR DESCRIPTION
1. 由于[unique_lock无法安全的跨线程使用](https://stackoverflow.com/questions/18937564/unique-lock-across-threads)，使用[condition_variable_any](http://en.cppreference.com/w/cpp/thread/condition_variable_any) + mutex替换 condition_variable + unique_lock + mutex，且可以节省一次lock()调用；
2. 使用[std::thread](http://en.cppreference.com/w/cpp/thread/thread)实现了Thread，移除了未使用且无法移植的ThreadAttr类和Thread::kill()，Thread::start(ThreadAttr&)函数；
3. 使用[std::this_thread::sleep_for](http://en.cppreference.com/w/cpp/thread/sleep_for)改写了sleep相关函数。
